### PR TITLE
RestaurantDetails wasn't refresh after Edit

### DIFF
--- a/app/src/main/java/pl/pawbal/mealsdistributor/data/models/dto/factory/bundle/RestaurantBundleFactory.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/data/models/dto/factory/bundle/RestaurantBundleFactory.java
@@ -7,23 +7,19 @@ import androidx.annotation.Nullable;
 import com.google.gson.Gson;
 
 import pl.pawbal.mealsdistributor.data.models.dto.base.Restaurant;
-import pl.pawbal.mealsdistributor.data.models.dto.response.restaurant.GetRestaurant;
 
 public class RestaurantBundleFactory {
-    private static final String GET_RESTAURANT_BUNDLE_KEY = "getRestaurant";
+    private static final String RESTAURANT_ID_BUNDLE_KEY = "restaurantId";
     private static final String RESTAURANT_BUNDLE_KEY = "restaurant";
 
-    public Bundle create(GetRestaurant restaurant) {
+    public Bundle create(String restaurantId) {
         Bundle bundle = new Bundle();
-        bundle.putString(GET_RESTAURANT_BUNDLE_KEY, new Gson().toJson(restaurant));
+        bundle.putString(RESTAURANT_ID_BUNDLE_KEY, restaurantId);
         return bundle;
     }
 
-    public GetRestaurant getRestaurant(@Nullable Bundle bundle) {
-        String getRestaurantJson = null;
-        if (bundle != null)
-            getRestaurantJson = bundle.getString(GET_RESTAURANT_BUNDLE_KEY);
-        return new Gson().fromJson(getRestaurantJson, GetRestaurant.class);
+    public String getRestaurantId(@Nullable Bundle bundle) {
+        return bundle != null ? bundle.getString(RESTAURANT_ID_BUNDLE_KEY) : "";
     }
 
     public Bundle create(Restaurant restaurant) {

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/action/error/RestaurantErrorHandler.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/action/error/RestaurantErrorHandler.java
@@ -47,13 +47,15 @@ public class RestaurantErrorHandler {
                     errorHandler.showToast(context, TAG, context.getResources().getString(R.string.add_restaurants_default_error_toast), t);
                     break;
             }
+        } else if (t instanceof NumberFormatException) {
+            errorHandler.showToast(context, TAG, context.getResources().getString(R.string.add_restaurant_nfe_error_toast), t);
         } else {
             errorHandler.showToast(context, TAG, context.getResources().getString(R.string.add_restaurants_default_error_toast), t);
         }
     }
 
     // TODO: May be unit tested
-    public void onGetRestaurantError(Throwable t, RestaurantMvpView view) {
+    public void onGetRestaurantError(Throwable t, RestaurantDetailsMvpView view) {
         view.hideLoading();
         if (t instanceof HttpException) {
             switch (((HttpException) t).code()) {
@@ -106,6 +108,8 @@ public class RestaurantErrorHandler {
                 default:
                     errorHandler.showToast(context, TAG, context.getResources().getString(R.string.edit_restaurant_default_error_toast), t);
             }
+        } else if (t instanceof NumberFormatException) {
+            errorHandler.showToast(context, TAG, context.getResources().getString(R.string.edit_restaurant_nfe_error_toast), t);
         } else {
             errorHandler.showToast(context, TAG, context.getResources().getString(R.string.edit_restaurant_default_error_toast), t);
         }

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/action/success/RestaurantSuccessHandler.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/action/success/RestaurantSuccessHandler.java
@@ -1,7 +1,5 @@
 package pl.pawbal.mealsdistributor.ui.action.success;
 
-import android.os.Bundle;
-
 import javax.inject.Inject;
 
 import pl.pawbal.mealsdistributor.data.models.dto.factory.bundle.RestaurantBundleFactory;
@@ -15,13 +13,11 @@ import pl.pawbal.mealsdistributor.ui.restaurant.edit.EditRestaurantMvpView;
 
 public class RestaurantSuccessHandler {
     private final SuccessHandler successHandler;
-    private final RestaurantBundleFactory restaurantBundleFactory;
 
     @Inject
     public RestaurantSuccessHandler(SuccessHandler successHandler,
                                     RestaurantBundleFactory restaurantBundleFactory) {
         this.successHandler = successHandler;
-        this.restaurantBundleFactory = restaurantBundleFactory;
     }
 
     public void onGetRestaurantsSuccess(GetRestaurants restaurants, RestaurantMvpView view) {
@@ -34,10 +30,9 @@ public class RestaurantSuccessHandler {
         view.goBack();
     }
 
-    public void onGetRestaurantSuccess(GetRestaurant restaurant, RestaurantMvpView view) {
+    public void onGetRestaurantSuccess(GetRestaurant restaurant, RestaurantDetailsMvpView view) {
         view.hideLoading();
-        Bundle getRestaurant = restaurantBundleFactory.create(restaurant);
-        view.navigateToRestaurantDetails(getRestaurant);
+        view.bindRestaurantDetails(restaurant);
     }
 
     public void onDeleteRestaurantSuccess(RestaurantDetailsMvpView view) {

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/RestaurantFragment.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/RestaurantFragment.java
@@ -75,7 +75,7 @@ public class RestaurantFragment extends BaseFragment implements RestaurantMvpVie
 
     private void onRestaurantViewHolderClick(View view) {
         TextView restaurantId = view.findViewById(R.id.tv_restaurant_id);
-        presenter.getRestaurant(restaurantId.getText().toString());
+        presenter.navigateToRestaurantDetails(restaurantId.getText().toString());
     }
 
     @OnClick(R.id.btn_restaurant_add)
@@ -100,16 +100,16 @@ public class RestaurantFragment extends BaseFragment implements RestaurantMvpVie
     }
 
     @Override
-    public void navigateToRestaurantDetails(Bundle getRestaurant) {
+    public void navigateToRestaurantDetails(Bundle bundle) {
         FragmentManager fragmentManager = getFragmentManager();
         if (fragmentManager != null) {
             Fragment fromStack = fragmentManager.findFragmentByTag(RestaurantDetailsFragment.TAG);
             if (fromStack == null) {
                 Fragment fragment = RestaurantDetailsFragment.newInstance();
-                fragment.setArguments(getRestaurant);
+                fragment.setArguments(bundle);
                 replaceFragment(fragmentManager, fragment, RestaurantDetailsFragment.TAG);
             } else {
-                fromStack.setArguments(getRestaurant);
+                fromStack.setArguments(bundle);
                 replaceFragment(fragmentManager, fromStack, RestaurantDetailsFragment.TAG);
             }
         }

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/RestaurantMvpPresenter.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/RestaurantMvpPresenter.java
@@ -5,5 +5,5 @@ import pl.pawbal.mealsdistributor.ui.base.MvpPresenter;
 public interface RestaurantMvpPresenter<V> extends MvpPresenter<V> {
     void getRestaurants();
 
-    void getRestaurant(String id);
+    void navigateToRestaurantDetails(String restaurantId);
 }

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/RestaurantMvpView.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/RestaurantMvpView.java
@@ -10,5 +10,5 @@ import pl.pawbal.mealsdistributor.ui.base.MvpView;
 public interface RestaurantMvpView extends MvpView {
     void bindRestaurantsToList(List<Restaurant> restaurants);
 
-    void navigateToRestaurantDetails(Bundle getRestaurant);
+    void navigateToRestaurantDetails(Bundle bundle);
 }

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/RestaurantPresenter.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/RestaurantPresenter.java
@@ -1,26 +1,32 @@
 package pl.pawbal.mealsdistributor.ui.restaurant;
 
+import android.os.Bundle;
+
 import javax.inject.Inject;
 
 import io.reactivex.disposables.CompositeDisposable;
 import pl.pawbal.mealsdistributor.data.api.service.RestaurantService;
 import pl.pawbal.mealsdistributor.data.api.service.wrapper.core.CustomSingleObserver;
+import pl.pawbal.mealsdistributor.data.models.dto.factory.bundle.RestaurantBundleFactory;
 import pl.pawbal.mealsdistributor.ui.action.error.RestaurantErrorHandler;
 import pl.pawbal.mealsdistributor.ui.action.success.RestaurantSuccessHandler;
 import pl.pawbal.mealsdistributor.ui.base.BasePresenter;
 
 public class RestaurantPresenter<V extends RestaurantMvpView> extends BasePresenter<V> implements RestaurantMvpPresenter<V> {
     private final RestaurantService restaurantService;
+    private final RestaurantBundleFactory restaurantBundleFactory;
     private final RestaurantSuccessHandler successHandler;
     private final RestaurantErrorHandler errorHandler;
 
     @Inject
     public RestaurantPresenter(CompositeDisposable compositeDisposable,
                                RestaurantService restaurantService,
+                               RestaurantBundleFactory restaurantBundleFactory,
                                RestaurantSuccessHandler successHandler,
                                RestaurantErrorHandler errorHandler) {
         super(compositeDisposable);
         this.restaurantService = restaurantService;
+        this.restaurantBundleFactory = restaurantBundleFactory;
         this.successHandler = successHandler;
         this.errorHandler = errorHandler;
     }
@@ -35,12 +41,8 @@ public class RestaurantPresenter<V extends RestaurantMvpView> extends BasePresen
     }
 
     @Override
-    public void getRestaurant(String id) {
-        getMvpView().showLoading();
-        restaurantService.getRestaurant(id, new CustomSingleObserver<>(
-                getCompositeDisposable(),
-                restaurant -> successHandler.onGetRestaurantSuccess(restaurant, getMvpView()),
-                t -> errorHandler.onGetRestaurantError(t, getMvpView())
-        ));
+    public void navigateToRestaurantDetails(String restaurantId) {
+        Bundle bundle = restaurantBundleFactory.create(restaurantId);
+        getMvpView().navigateToRestaurantDetails(bundle);
     }
 }

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/add/AddRestaurantPresenter.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/add/AddRestaurantPresenter.java
@@ -37,10 +37,18 @@ public class AddRestaurantPresenter<V extends AddRestaurantMvpView> extends Base
                               @Nullable String deliveryCost, @Nullable String maxPaidOrderValue,
                               boolean isPyszne) {
         getMvpView().showLoading();
-        AddRestaurant addRestaurant = restaurantFactory.create(name, phoneNumber, minOrderCost, deliveryCost, maxPaidOrderValue, isPyszne);
-        restaurantService.addRestaurant(addRestaurant, new CustomCompletableObserver(
-                getCompositeDisposable(),
-                () -> restaurantSuccessHandler.onAddRestaurantSuccess(getMvpView()),
-                t -> restaurantErrorHandler.onAddRestaurantError(t, getMvpView())));
+        tryAddRestaurant(name, phoneNumber, minOrderCost, deliveryCost, maxPaidOrderValue, isPyszne);
+    }
+
+    private void tryAddRestaurant(String name, String phoneNumber, @Nullable String minOrderCost, @Nullable String deliveryCost, @Nullable String maxPaidOrderValue, boolean isPyszne) {
+        try {
+            AddRestaurant addRestaurant = restaurantFactory.create(name, phoneNumber, minOrderCost, deliveryCost, maxPaidOrderValue, isPyszne);
+            restaurantService.addRestaurant(addRestaurant, new CustomCompletableObserver(
+                    getCompositeDisposable(),
+                    () -> restaurantSuccessHandler.onAddRestaurantSuccess(getMvpView()),
+                    t -> restaurantErrorHandler.onAddRestaurantError(t, getMvpView())));
+        } catch (NumberFormatException exception) {
+            restaurantErrorHandler.onAddRestaurantError(exception, getMvpView());
+        }
     }
 }

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/details/RestaurantDetailsFragment.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/details/RestaurantDetailsFragment.java
@@ -79,7 +79,7 @@ public class RestaurantDetailsFragment extends BaseFragment implements Restauran
 
     private void bindRestaurantDetails() {
         Bundle bundle = getArguments();
-        presenter.bindGetRestaurant(bundle);
+        presenter.getRestaurant(bundle);
     }
 
     private void setIcon() {
@@ -92,11 +92,11 @@ public class RestaurantDetailsFragment extends BaseFragment implements Restauran
         this.restaurant = restaurant.getRestaurant();
         restaurantName.setText(restaurant.getRestaurant().getName());
         restaurantPhoneNumber.setText(restaurant.getRestaurant().getPhoneNumber());
-        String minOrderCost = BigDecimalFormatUtil.format(restaurant.getRestaurant().getMinOrderCost());
+        String minOrderCost = BigDecimalFormatUtil.formatWithCurrency(restaurant.getRestaurant().getMinOrderCost());
         restaurantMinOrderCost.setText(minOrderCost != null ? minOrderCost : requireContext().getResources().getText(R.string.no_info));
-        String deliveryCost = BigDecimalFormatUtil.format(restaurant.getRestaurant().getDeliveryCost());
+        String deliveryCost = BigDecimalFormatUtil.formatWithCurrency(restaurant.getRestaurant().getDeliveryCost());
         restaurantDeliveryCost.setText(deliveryCost != null ? deliveryCost : requireContext().getResources().getText(R.string.no_info));
-        String maxPaidOrderValue = BigDecimalFormatUtil.format(restaurant.getRestaurant().getMaxPaidOrderValue());
+        String maxPaidOrderValue = BigDecimalFormatUtil.formatWithCurrency(restaurant.getRestaurant().getMaxPaidOrderValue());
         restaurantMaxPaidOrderValue.setText(maxPaidOrderValue != null ? maxPaidOrderValue : requireContext().getResources().getText(R.string.no_info));
     }
 

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/details/RestaurantDetailsMvpPresenter.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/details/RestaurantDetailsMvpPresenter.java
@@ -2,13 +2,11 @@ package pl.pawbal.mealsdistributor.ui.restaurant.details;
 
 import android.os.Bundle;
 
-import androidx.annotation.Nullable;
-
 import pl.pawbal.mealsdistributor.data.models.dto.base.Restaurant;
 import pl.pawbal.mealsdistributor.ui.base.MvpPresenter;
 
 public interface RestaurantDetailsMvpPresenter<V> extends MvpPresenter<V> {
-    void bindGetRestaurant(@Nullable Bundle bundle);
+    void getRestaurant(Bundle bundle);
 
     void deleteRestaurant(String id);
 

--- a/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/edit/EditRestaurantPresenter.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/ui/restaurant/edit/EditRestaurantPresenter.java
@@ -50,11 +50,19 @@ public class EditRestaurantPresenter<V extends EditRestaurantMvpView> extends Ba
                                @Nullable String deliveryCost, @Nullable String maxPaidOrderValue,
                                boolean isPyszne) {
         getMvpView().showLoading();
-        EditRestaurant body = restaurantFactory.create(id, name, phoneNumber, minOrderCost, deliveryCost, maxPaidOrderValue, isPyszne);
-        restaurantService.editRestaurant(body, new CustomCompletableObserver(
-                getCompositeDisposable(),
-                () -> successHandler.onEditRestaurantSuccess(getMvpView()),
-                t -> errorHandler.onEditRestaurantError(t, getMvpView())
-        ));
+        tryEditRestaurant(id, name, phoneNumber, minOrderCost, deliveryCost, maxPaidOrderValue, isPyszne);
+    }
+
+    private void tryEditRestaurant(String id, String name, String phoneNumber, @Nullable String minOrderCost, @Nullable String deliveryCost, @Nullable String maxPaidOrderValue, boolean isPyszne) {
+        try {
+            EditRestaurant body = restaurantFactory.create(id, name, phoneNumber, minOrderCost, deliveryCost, maxPaidOrderValue, isPyszne);
+            restaurantService.editRestaurant(body, new CustomCompletableObserver(
+                    getCompositeDisposable(),
+                    () -> successHandler.onEditRestaurantSuccess(getMvpView()),
+                    t -> errorHandler.onEditRestaurantError(t, getMvpView())
+            ));
+        } catch (NumberFormatException exception) {
+            errorHandler.onEditRestaurantError(exception, getMvpView());
+        }
     }
 }

--- a/app/src/main/java/pl/pawbal/mealsdistributor/util/BigDecimalFormatUtil.java
+++ b/app/src/main/java/pl/pawbal/mealsdistributor/util/BigDecimalFormatUtil.java
@@ -14,14 +14,24 @@ public class BigDecimalFormatUtil {
     }
 
     @Nullable
-    public BigDecimal format(@Nullable String decimal) {
-        return decimal != null && !decimal.isEmpty() ?
-                new BigDecimal(decimal) :
-                null;
+    public BigDecimal format(@Nullable String decimal) throws NumberFormatException {
+        if (decimal == null || decimal.isEmpty())
+            return null;
+        decimal = decimal.replace(",", ".");
+        return new BigDecimal(decimal);
     }
 
     @Nullable
     public static String format(@Nullable BigDecimal decimal) {
+        NumberFormat numberFormat = NumberFormat.getInstance();
+        numberFormat.setMaximumFractionDigits(2);
+        return decimal != null ?
+                numberFormat.format(decimal) :
+                null;
+    }
+
+    @Nullable
+    public static String formatWithCurrency(@Nullable BigDecimal decimal) {
         return decimal != null ?
                 NumberFormat.getCurrencyInstance(new Locale("pl", "PL")).format(decimal) :
                 null;

--- a/app/src/main/res/layout/fragment_restaurant_details.xml
+++ b/app/src/main/res/layout/fragment_restaurant_details.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/fragment_restaurant_details"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -59,10 +60,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="8dp"
-                android:text="@string/example"
                 android:textSize="@dimen/h4"
                 app:layout_constraintStart_toEndOf="@id/tv_restaurant_details_icon"
-                app:layout_constraintTop_toBottomOf="@id/tv_restaurant_details_const_title" />
+                app:layout_constraintTop_toBottomOf="@id/tv_restaurant_details_const_title"
+                tools:text="@string/example" />
 
             <TextView
                 android:id="@+id/tv_restaurant_details_phone_number"
@@ -70,10 +71,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="2dp"
-                android:text="@string/example"
                 android:textSize="@dimen/h5"
                 app:layout_constraintStart_toEndOf="@id/tv_restaurant_details_icon"
-                app:layout_constraintTop_toBottomOf="@id/tv_restaurant_details_name" />
+                app:layout_constraintTop_toBottomOf="@id/tv_restaurant_details_name"
+                tools:text="@string/example" />
 
             <TextView
                 android:id="@+id/tv_restaurant_details_additional_info"
@@ -103,10 +104,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="8dp"
-                android:text="@string/example_number"
                 android:textSize="@dimen/body_1"
                 app:layout_constraintStart_toEndOf="@+id/tv_restaurant_details_const_min_order_cost"
-                app:layout_constraintTop_toBottomOf="@+id/tv_restaurant_details_additional_info" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_restaurant_details_additional_info"
+                tools:text="@string/example_number" />
 
             <TextView
                 android:id="@+id/tv_restaurant_details_const_delivery_cost"
@@ -125,10 +126,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="8dp"
-                android:text="@string/example_number"
                 android:textSize="@dimen/body_1"
                 app:layout_constraintStart_toEndOf="@+id/tv_restaurant_details_const_delivery_cost"
-                app:layout_constraintTop_toBottomOf="@+id/tv_restaurant_details_const_min_order_cost" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_restaurant_details_const_min_order_cost"
+                tools:text="@string/example_number" />
 
             <TextView
                 android:id="@+id/tv_restaurant_details_const_max_paid_order_value"
@@ -147,10 +148,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="8dp"
-                android:text="@string/example_number"
                 android:textSize="@dimen/body_1"
                 app:layout_constraintStart_toEndOf="@+id/tv_restaurant_details_const_max_paid_order_value"
-                app:layout_constraintTop_toBottomOf="@+id/tv_restaurant_details_const_delivery_cost" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_restaurant_details_const_delivery_cost"
+                tools:text="@string/example_number" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -166,8 +167,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="24dp"
-                    android:text="@string/edit"
                     android:backgroundTint="@color/defaultButtonColor"
+                    android:text="@string/edit"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Button"
                     android:textColor="@color/defaultTextColor"
                     android:textSize="@dimen/body_1" />
@@ -178,8 +179,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="24dp"
-                    android:text="@string/delete"
                     android:backgroundTint="@color/warningButtonColor"
+                    android:text="@string/delete"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Button"
                     android:textColor="@color/defaultTextColor"
                     android:textSize="@dimen/body_1" />

--- a/app/src/main/res/values/errors.xml
+++ b/app/src/main/res/values/errors.xml
@@ -5,6 +5,7 @@
     <string name="login_default_error_toast">Logowanie nie powiodło się, proszę spróbować ponownie.</string>
     <string name="get_restaurants_default_error_toast">Nie udało się pobrać listy restauracji, proszę spróbować ponownie.</string>
     <string name="add_restaurants_default_error_toast">Nie udało się dodać nowej restauracji, proszę spróbować ponownie.</string>
+    <string name="add_restaurant_nfe_error_toast">Dodawanie nowej restauracji nie powiodło się. Minimalny koszt zamówienia, koszt dostawy oraz koszt darmowej dostawy muszą być wartościami liczbowymi.</string>
     <string name="add_restaurants_400_error_toast">Nie udało się dodać nowej restauracji, proszę sprawdzić poprawność danych.</string>
     <string name="add_restaurants_403_error_toast">Nie udało się dodać nowej restauracji, nie masz dostępu do tej funkcjonalności.</string>
     <string name="get_restaurant_default_error_toast">Nie udało się pobrać wymaganych informacji, proszę spróbować ponownie.</string>
@@ -14,6 +15,7 @@
     <string name="delete_restaurant_403_error_toast">Nie posiadasz dostępu do usunięcia tej restauracji.</string>
     <string name="delete_restaurant_404_error_toast">Podana restauracja do usunięcia nie istnieje w systemie.</string>
     <string name="edit_restaurant_default_error_toast">Edycja restauracji nie powiodła się, proszę spróbować ponownie.</string>
+    <string name="edit_restaurant_nfe_error_toast">Edycja restauracji nie powiodła się. Minimalny koszt zamówienia, koszt dostawy oraz koszt darmowej dostawy muszą być wartościami liczbowymi.</string>
     <string name="edit_restaurant_400_error_toast">Edycja restauracji nie powiodła się, proszę sprawdzić poprawność danych.</string>
     <string name="edit_restaurant_403_error_toast">Nie posiadasz dostępu do edycji tej restauracji.</string>
     <string name="edit_restaurant_404_error_toast">Edytowana restauracja nie została odnaleziona w systemie, proszę spróbować ponownie.</string>

--- a/app/src/test/java/pl/pawbal/mealsdistributor/ui/action/success/RestaurantSuccessHandlerTest.java
+++ b/app/src/test/java/pl/pawbal/mealsdistributor/ui/action/success/RestaurantSuccessHandlerTest.java
@@ -1,7 +1,5 @@
 package pl.pawbal.mealsdistributor.ui.action.success;
 
-import android.os.Bundle;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,7 +19,6 @@ import pl.pawbal.mealsdistributor.ui.restaurant.details.RestaurantDetailsMvpView
 import pl.pawbal.mealsdistributor.ui.restaurant.edit.EditRestaurantMvpView;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RestaurantSuccessHandlerTest {
@@ -65,17 +62,14 @@ class RestaurantSuccessHandlerTest {
     void onGetRestaurantSuccess() {
         //given
         GetRestaurant restaurant = new GetRestaurant();
-        RestaurantMvpView view = Mockito.mock(RestaurantMvpView.class);
-        Bundle getRestaurant = new Bundle();
-        when(restaurantBundleFactory.create(restaurant)).thenReturn(getRestaurant);
+        RestaurantDetailsMvpView view = Mockito.mock(RestaurantDetailsMvpView.class);
 
         //when
         successHandler.onGetRestaurantSuccess(restaurant, view);
 
         //then
         verify(view).hideLoading();
-        verify(restaurantBundleFactory).create(restaurant);
-        verify(view).navigateToRestaurantDetails(getRestaurant);
+        verify(view).bindRestaurantDetails(restaurant);
     }
 
     @Test


### PR DESCRIPTION
Updated:

- RestaurantBundleFactory:
  - doesn't create Bundle with getRestaurant anymore and reverse
  - now creates Bundle from restaurantId and reverse
- RestaurantErrorHandler:
  - onGetRestaurantError now takes RestaurantDetailsMvpView
  - onEditRestaurantError supports new Exception type (NumberFormatException)
  - onAddRestaurantError supports new Exception type (NumberFormatException)
- RestaurantSuccessHandler:
  - onGetRestaurantSuccess implementation update
  - test update
- AddRestaurantPresenter:
  - now tries to add restaurant (RuntimeException may be thrown)
- RestaurantDetailsFragment:
  - refactor
- RestaurantDetailsMvpPresenter + RestaurantDetailsPresenter:
  - bindGetRestaurant -> getRestaurant - implementation update (Bundle now contains just restaurantId)
- EditRestaurantPresenter:
  - now tries to edit restaurant (RuntimeException may be thrown)
- RestaurantFragment + RestaurantMvpView + RestaurantPresenter + RestaurantMvpPresenter:
  - now it just send restaurantId to restaurantDetails
- BigDecimalFormatUtil:
  - implementation update + info about RuntimeException
- resources update:
  - fragment_restaurant_details uses tools:text :)
  - new error's strings